### PR TITLE
fix: handle expired auth gracefully and preserve credentials on upgrade

### DIFF
--- a/src/accounts_add_delete.py
+++ b/src/accounts_add_delete.py
@@ -42,6 +42,8 @@ elif _type == "_new":
     elif _origin == "sync":
         plex_account = get_plex_account(uuid=_input)
     if not plex_account:
+        # Auth failed - get_plex_account already shows notification, but log for debugging
+        custom_logger("error", f"Failed to authenticate via {_origin}")
         exit()
     replace = False
     json_obj = {

--- a/src/search_entry.py
+++ b/src/search_entry.py
@@ -140,7 +140,15 @@ def register_elements(database: list, plex_uuid: str, watchlist: str):
     }
 
     plex_account = get_plex_account(uuid=plex_uuid)
-    watchlist_guids = set([elem.guid for elem in plex_account.watchlist()])
+    if plex_account is None:
+        # Auth failed - still show results but skip watchlist features
+        watchlist_guids = set()
+    else:
+        try:
+            watchlist_guids = set([elem.guid for elem in plex_account.watchlist()])
+        except Exception as e:
+            custom_logger("warning", f"Failed to fetch watchlist: {e}")
+            watchlist_guids = set()
     filter_database = database
     if watchlist == 1:
         filter_database = [media for media in database if media.guid in watchlist_guids]
@@ -279,7 +287,7 @@ def register_elements(database: list, plex_uuid: str, watchlist: str):
                         }
                     )
 
-            if short_watchlist != "":
+            if short_watchlist != "" and plex_account is not None:
                 media_guid = media.guid
                 isInWatchlist = True if media_guid in watchlist_guids else False
                 action = "delete" if isInWatchlist else "add"

--- a/src/utils.py
+++ b/src/utils.py
@@ -113,9 +113,11 @@ def custom_logger(level: str, message: str):
 
 
 def delete_files(element):
+    # Files to preserve across version upgrades (user authentication data)
+    preserve_files = {"presets.json", "accounts.json", "servers.json"}
     if os.path.exists(element):
         for file in os.listdir(element):
-            if not file.endswith(".app") and file != "presets.json":
+            if not file.endswith(".app") and file not in preserve_files:
                 file_path = os.path.join(element, file)
                 try:
                     os.remove(file_path)
@@ -147,7 +149,9 @@ plex_app_version = os.getenv("alfred_workflow_version", "")
 config = configparser.ConfigParser()
 if os.path.exists(config_file_path):
     config.read(config_file_path)
-    if plex_app_version != config["header"]["version"]:
+    # Only check version if running from Alfred (env var is set)
+    # This prevents accidental cleanup when running scripts from terminal
+    if plex_app_version and plex_app_version != config["header"]["version"]:
         for folder in [data_folder, cache_folder]:
             delete_files(folder)
 


### PR DESCRIPTION
## Summary

Fixes #13 which was due to an expired Plex token, but there was no obvious feedback in the logs or to the user.

This PR addresses several authentication handling issues:

- **Silent auth failure**: When `get_plex_account()` returns `None` due to expired/invalid tokens, the workflow would crash with `'NoneType' object has no attribute 'watchlist'`. Now it gracefully degrades - search results are still shown but watchlist features are disabled until re-authentication.

- **Version upgrade wipes credentials**: The version check in `utils.py` would delete ALL files including `accounts.json` and `servers.json` when the workflow version changes. This forced users to re-authenticate after every update. Now authentication files are preserved.

- **Terminal debugging safety**: The version check now only runs when the Alfred environment variable is set, preventing accidental cleanup when running scripts from terminal for debugging.

- **Auth failure logging**: Added logging when authentication fails in `accounts_add_delete.py` to help with debugging.